### PR TITLE
fix : Apple 콜백 redirect 307 → 302 수정 (405 오류 해결)

### DIFF
--- a/src/app/api/auth/apple/callback/route.ts
+++ b/src/app/api/auth/apple/callback/route.ts
@@ -16,13 +16,15 @@ export async function POST(request: NextRequest) {
 
     if (error) {
       return NextResponse.redirect(
-        new URL(`/auth/login?error=apple_${error}`, request.url)
+        new URL(`/auth/login?error=apple_${error}`, request.url),
+        302
       );
     }
 
     if (!idToken) {
       return NextResponse.redirect(
-        new URL('/auth/login?error=no_id_token', request.url)
+        new URL('/auth/login?error=no_id_token', request.url),
+        302
       );
     }
 
@@ -43,17 +45,20 @@ export async function POST(request: NextRequest) {
     }
 
     // 클라이언트 콜백 페이지로 GET redirect
+    // 302를 명시해야 브라우저가 POST → GET으로 전환함 (기본값 307은 POST 유지 → 405 발생)
     const redirectParams = new URLSearchParams({ sub });
     if (email) redirectParams.set('email', email);
     if (name) redirectParams.set('name', name);
 
     return NextResponse.redirect(
-      new URL(`/auth/apple/callback?${redirectParams.toString()}`, request.url)
+      new URL(`/auth/apple/callback?${redirectParams.toString()}`, request.url),
+      302
     );
   } catch (err) {
     console.error('Apple callback error:', err);
     return NextResponse.redirect(
-      new URL('/auth/login?error=apple_callback_failed', request.url)
+      new URL('/auth/login?error=apple_callback_failed', request.url),
+      302
     );
   }
 }


### PR DESCRIPTION
## Summary

- Apple 콜백 API Route의 redirect 상태코드 307 → 302 수정

## 원인

`NextResponse.redirect()` 기본값이 **307**이라 POST 메서드가 유지된 채 클라이언트 페이지로 redirect됨
클라이언트 페이지는 POST 핸들러가 없으므로 **HTTP 405** 발생

```
Apple → POST /api/auth/apple/callback
         → 307 redirect
         → 브라우저 POST /auth/apple/callback  ← 405
```

## 수정

```
Apple → POST /api/auth/apple/callback
         → 302 redirect
         → 브라우저 GET /auth/apple/callback   ← 정상
```

## Test plan

- [ ] Apple 로그인 후 `/auth/apple/callback` 페이지 정상 로드 확인 (405 없음)
- [ ] 백엔드로 `{ provider: 'APPLE', providerUserId: sub }` 요청 전송 확인
- [ ] 신규 유저: `/auth/additional-info` 이동 확인
- [ ] 기존 유저: `/hex` 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)